### PR TITLE
Add Metal compute shader compositor for macOS/iOS

### DIFF
--- a/ios/Classes/DartPsdToolPlugin.swift
+++ b/ios/Classes/DartPsdToolPlugin.swift
@@ -1,0 +1,91 @@
+import Flutter
+import UIKit
+
+/// Flutter plugin for PSD Metal compositing on iOS.
+public class DartPsdToolPlugin: NSObject, FlutterPlugin {
+    private var compositor: PsdMetalCompositor?
+
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: "dart_psd_tool/metal",
+            binaryMessenger: registrar.messenger()
+        )
+        let instance = DartPsdToolPlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "isAvailable":
+            result(PsdMetalCompositor.isAvailable)
+
+        case "initialize":
+            do {
+                compositor = try PsdMetalCompositor()
+                result(true)
+            } catch {
+                result(FlutterError(
+                    code: "METAL_INIT_FAILED",
+                    message: error.localizedDescription,
+                    details: nil
+                ))
+            }
+
+        case "composite":
+            guard let compositor = compositor else {
+                result(FlutterError(
+                    code: "NOT_INITIALIZED",
+                    message: "Metal compositor not initialized. Call initialize() first.",
+                    details: nil
+                ))
+                return
+            }
+
+            guard let args = call.arguments as? [String: Any],
+                  let srcBytes = args["src"] as? FlutterStandardTypedData,
+                  let dstBytes = args["dst"] as? FlutterStandardTypedData,
+                  let width = args["width"] as? Int,
+                  let height = args["height"] as? Int,
+                  let blendMode = args["blendMode"] as? Int,
+                  let opacity = args["opacity"] as? Double else {
+                result(FlutterError(
+                    code: "INVALID_ARGS",
+                    message: "Missing or invalid arguments",
+                    details: nil
+                ))
+                return
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let output = try compositor.composite(
+                        srcBytes: srcBytes.data,
+                        dstBytes: dstBytes.data,
+                        width: width,
+                        height: height,
+                        blendMode: blendMode,
+                        opacity: Float(opacity)
+                    )
+                    DispatchQueue.main.async {
+                        result(FlutterStandardTypedData(bytes: output))
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        result(FlutterError(
+                            code: "COMPOSITE_FAILED",
+                            message: error.localizedDescription,
+                            details: nil
+                        ))
+                    }
+                }
+            }
+
+        case "dispose":
+            compositor = nil
+            result(nil)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+}

--- a/ios/Classes/PsdMetalCompositor.swift
+++ b/ios/Classes/PsdMetalCompositor.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Metal
+
+/// Native Metal compositor for PSD blending (iOS).
+///
+/// Uses a Metal compute shader to perform PSDTool-compatible 3-component
+/// alpha compositing on the GPU. All 26 PSD blend modes are supported.
+public class PsdMetalCompositor {
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let pipelineState: MTLComputePipelineState
+
+    init() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw MetalError.noDevice
+        }
+        self.device = device
+
+        guard let commandQueue = device.makeCommandQueue() else {
+            throw MetalError.noCommandQueue
+        }
+        self.commandQueue = commandQueue
+
+        // Load the Metal shader library from the plugin bundle
+        let bundle = Bundle(for: PsdMetalCompositor.self)
+        guard let libraryURL = bundle.url(forResource: "default", withExtension: "metallib")
+              ?? bundle.url(forResource: "psd_composite", withExtension: "metallib") else {
+            // Fallback: compile from source at runtime
+            guard let metalURL = bundle.url(forResource: "psd_composite", withExtension: "metal") else {
+                throw MetalError.noShaderSource
+            }
+            let source = try String(contentsOf: metalURL)
+            let library = try device.makeLibrary(source: source, options: nil)
+            guard let function = library.makeFunction(name: "psdComposite") else {
+                throw MetalError.noFunction
+            }
+            self.pipelineState = try device.makeComputePipelineState(function: function)
+            return
+        }
+        let library = try device.makeLibrary(URL: libraryURL)
+        guard let function = library.makeFunction(name: "psdComposite") else {
+            throw MetalError.noFunction
+        }
+        self.pipelineState = try device.makeComputePipelineState(function: function)
+    }
+
+    /// Composite src onto dst using the specified blend mode.
+    func composite(
+        srcBytes: Data,
+        dstBytes: Data,
+        width: Int,
+        height: Int,
+        blendMode: Int,
+        opacity: Float
+    ) throws -> Data {
+        let pixelCount = width * height
+        let bufferSize = pixelCount * 4
+
+        guard srcBytes.count >= bufferSize, dstBytes.count >= bufferSize else {
+            throw MetalError.invalidBufferSize
+        }
+
+        guard let srcBuffer = device.makeBuffer(bytes: (srcBytes as NSData).bytes,
+                                                 length: bufferSize,
+                                                 options: .storageModeShared),
+              let dstBuffer = device.makeBuffer(bytes: (dstBytes as NSData).bytes,
+                                                 length: bufferSize,
+                                                 options: .storageModeShared),
+              let outBuffer = device.makeBuffer(length: bufferSize,
+                                                options: .storageModeShared) else {
+            throw MetalError.bufferCreationFailed
+        }
+
+        var params = CompositeParams(
+            width: UInt32(width),
+            height: UInt32(height),
+            opacity: opacity,
+            blendMode: Int32(blendMode)
+        )
+
+        guard let paramsBuffer = device.makeBuffer(bytes: &params,
+                                                    length: MemoryLayout<CompositeParams>.size,
+                                                    options: .storageModeShared) else {
+            throw MetalError.bufferCreationFailed
+        }
+
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else {
+            throw MetalError.encodingFailed
+        }
+
+        encoder.setComputePipelineState(pipelineState)
+        encoder.setBuffer(srcBuffer, offset: 0, index: 0)
+        encoder.setBuffer(dstBuffer, offset: 0, index: 1)
+        encoder.setBuffer(outBuffer, offset: 0, index: 2)
+        encoder.setBuffer(paramsBuffer, offset: 0, index: 3)
+
+        // Use non-uniform dispatch for iOS devices that support it
+        let threadgroupSize = MTLSize(
+            width: min(16, pipelineState.maxTotalThreadsPerThreadgroup),
+            height: min(16, pipelineState.maxTotalThreadsPerThreadgroup / 16),
+            depth: 1
+        )
+        let gridSize = MTLSize(width: width, height: height, depth: 1)
+
+        if device.supportsFamily(.apple4) {
+            encoder.dispatchThreads(gridSize, threadsPerThreadgroup: threadgroupSize)
+        } else {
+            // Fallback for older devices
+            let threadgroupCount = MTLSize(
+                width: (width + threadgroupSize.width - 1) / threadgroupSize.width,
+                height: (height + threadgroupSize.height - 1) / threadgroupSize.height,
+                depth: 1
+            )
+            encoder.dispatchThreadgroups(threadgroupCount, threadsPerThreadgroup: threadgroupSize)
+        }
+
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        if let error = commandBuffer.error {
+            throw MetalError.executionFailed(error.localizedDescription)
+        }
+
+        let outputPointer = outBuffer.contents().bindMemory(to: UInt8.self, capacity: bufferSize)
+        return Data(bytes: outputPointer, count: bufferSize)
+    }
+
+    static var isAvailable: Bool {
+        return MTLCreateSystemDefaultDevice() != nil
+    }
+}
+
+struct CompositeParams {
+    var width: UInt32
+    var height: UInt32
+    var opacity: Float
+    var blendMode: Int32
+}
+
+enum MetalError: Error, LocalizedError {
+    case noDevice
+    case noCommandQueue
+    case noShaderSource
+    case noFunction
+    case invalidBufferSize
+    case bufferCreationFailed
+    case encodingFailed
+    case executionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noDevice: return "No Metal device available"
+        case .noCommandQueue: return "Failed to create command queue"
+        case .noShaderSource: return "Metal shader source not found"
+        case .noFunction: return "Metal function 'psdComposite' not found"
+        case .invalidBufferSize: return "Buffer size does not match dimensions"
+        case .bufferCreationFailed: return "Failed to create Metal buffer"
+        case .encodingFailed: return "Failed to create command encoder"
+        case .executionFailed(let msg): return "Metal execution failed: \(msg)"
+        }
+    }
+}

--- a/ios/Classes/psd_composite.metal
+++ b/ios/Classes/psd_composite.metal
@@ -1,0 +1,264 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// ── Per-channel blend functions ──
+
+static float3 blendNormal(float3 s, float3 d)     { return s; }
+static float3 blendMultiply(float3 s, float3 d)   { return s * d; }
+static float3 blendScreen(float3 s, float3 d)     { return s + d - s * d; }
+
+static float3 blendOverlay(float3 s, float3 d) {
+    return mix(
+        2.0 * s * d,
+        1.0 - 2.0 * (1.0 - s) * (1.0 - d),
+        step(0.5, d)
+    );
+}
+
+static float3 blendDarken(float3 s, float3 d)     { return min(s, d); }
+static float3 blendLighten(float3 s, float3 d)    { return max(s, d); }
+
+static float3 blendColorDodge(float3 s, float3 d) {
+    return mix(
+        mix(min(float3(1.0), d / max(1.0 - s, 1.0 / 255.0)), float3(1.0), step(1.0, s)),
+        float3(0.0),
+        step(d, float3(0.0))
+    );
+}
+
+static float3 blendColorBurn(float3 s, float3 d) {
+    return mix(
+        mix(1.0 - min(float3(1.0), (1.0 - d) / max(s, 1.0 / 255.0)), float3(0.0), step(s, float3(0.0))),
+        float3(1.0),
+        step(1.0, d)
+    );
+}
+
+static float3 blendHardLight(float3 s, float3 d) {
+    return mix(
+        2.0 * s * d,
+        1.0 - 2.0 * (1.0 - s) * (1.0 - d),
+        step(0.5, s)
+    );
+}
+
+static float3 blendSoftLight(float3 s, float3 d) {
+    float3 dd = mix(
+        sqrt(d),
+        ((16.0 * d - 12.0) * d + 4.0) * d,
+        step(d, float3(0.25))
+    );
+    return mix(
+        d - (1.0 - 2.0 * s) * d * (1.0 - d),
+        d + (2.0 * s - 1.0) * (dd - d),
+        step(0.5, s)
+    );
+}
+
+static float3 blendDifference(float3 s, float3 d) { return abs(s - d); }
+static float3 blendSubtract(float3 s, float3 d)   { return max(float3(0.0), d - s); }
+static float3 blendLinearDodge(float3 s, float3 d) { return min(float3(1.0), s + d); }
+
+static float3 blendDivide(float3 s, float3 d) {
+    float3 eps = float3(1.0 / 255.0);
+    return mix(
+        min(float3(1.0), d / max(s, eps)),
+        mix(float3(0.0), float3(1.0), step(eps, d)),
+        step(s, float3(0.0))
+    );
+}
+
+static float3 blendExclusion(float3 s, float3 d) { return s + d - 2.0 * s * d; }
+static float3 blendLinearBurn(float3 s, float3 d) { return max(float3(0.0), s + d - 1.0); }
+
+static float3 blendVividLight(float3 s, float3 d) {
+    return mix(
+        blendColorBurn(2.0 * s, d),
+        blendColorDodge(2.0 * s - 1.0, d),
+        step(0.5, s)
+    );
+}
+
+static float3 blendLinearLight(float3 s, float3 d) { return clamp(d + 2.0 * s - 1.0, 0.0, 1.0); }
+
+static float3 blendPinLight(float3 s, float3 d) {
+    return mix(
+        min(d, 2.0 * s),
+        max(d, 2.0 * s - 1.0),
+        step(0.5, s)
+    );
+}
+
+static float3 blendHardMix(float3 s, float3 d) {
+    return step(0.5, blendVividLight(s, d));
+}
+
+// ── HSL helper functions (W3C Compositing and Blending Level 1) ──
+
+static float lum(float3 c) { return 0.299 * c.r + 0.587 * c.g + 0.114 * c.b; }
+
+static float sat(float3 c) { return max(c.r, max(c.g, c.b)) - min(c.r, min(c.g, c.b)); }
+
+static float3 clipColor(float3 c) {
+    float l = lum(c);
+    float n = min(c.r, min(c.g, c.b));
+    float x = max(c.r, max(c.g, c.b));
+    if (n < 0.0) {
+        c = l + (c - l) * l / (l - n);
+    }
+    if (x > 1.0) {
+        c = l + (c - l) * (1.0 - l) / (x - l);
+    }
+    return clamp(c, 0.0, 1.0);
+}
+
+static float3 setLum(float3 c, float l) {
+    float d = l - lum(c);
+    return clipColor(c + d);
+}
+
+static float3 setSat(float3 c, float s) {
+    float cmin = min(c.r, min(c.g, c.b));
+    float cmax = max(c.r, max(c.g, c.b));
+
+    if (cmax > cmin) {
+        return (c - cmin) * s / (cmax - cmin);
+    }
+    return float3(0.0);
+}
+
+// ── Per-pixel blend modes (index 20-25) ──
+
+static float3 blendDarkerColor(float3 s, float3 d) {
+    return lum(s) < lum(d) ? s : d;
+}
+
+static float3 blendLighterColor(float3 s, float3 d) {
+    return lum(s) > lum(d) ? s : d;
+}
+
+static float3 blendHue(float3 s, float3 d) {
+    return setLum(setSat(s, sat(d)), lum(d));
+}
+
+static float3 blendSaturation(float3 s, float3 d) {
+    return setLum(setSat(d, sat(s)), lum(d));
+}
+
+static float3 blendColor(float3 s, float3 d) {
+    return setLum(s, lum(d));
+}
+
+static float3 blendLuminosity(float3 s, float3 d) {
+    return setLum(d, lum(s));
+}
+
+// ── Dispatch blend mode by index ──
+
+static float3 blendPixels(float3 s, float3 d, int mode) {
+    switch (mode) {
+        case 0:  return blendNormal(s, d);
+        case 1:  return blendMultiply(s, d);
+        case 2:  return blendScreen(s, d);
+        case 3:  return blendOverlay(s, d);
+        case 4:  return blendDarken(s, d);
+        case 5:  return blendLighten(s, d);
+        case 6:  return blendColorDodge(s, d);
+        case 7:  return blendColorBurn(s, d);
+        case 8:  return blendHardLight(s, d);
+        case 9:  return blendSoftLight(s, d);
+        case 10: return blendDifference(s, d);
+        case 11: return blendSubtract(s, d);
+        case 12: return blendLinearDodge(s, d);
+        case 13: return blendDivide(s, d);
+        case 14: return blendExclusion(s, d);
+        case 15: return blendLinearBurn(s, d);
+        case 16: return blendVividLight(s, d);
+        case 17: return blendLinearLight(s, d);
+        case 18: return blendPinLight(s, d);
+        case 19: return blendHardMix(s, d);
+        case 20: return blendDarkerColor(s, d);
+        case 21: return blendLighterColor(s, d);
+        case 22: return blendHue(s, d);
+        case 23: return blendSaturation(s, d);
+        case 24: return blendColor(s, d);
+        case 25: return blendLuminosity(s, d);
+        default: return blendNormal(s, d);
+    }
+}
+
+// ── Uniforms ──
+
+struct CompositeParams {
+    uint width;
+    uint height;
+    float opacity;
+    int blendMode;  // 0=Normal .. 25=Luminosity
+};
+
+// ── Un-premultiply alpha ──
+
+static float4 unpremultiply(float4 c) {
+    if (c.a < 1.0 / 255.0) return float4(0.0);
+    return float4(c.rgb / c.a, c.a);
+}
+
+// ── Compute kernel ──
+// Input/output buffers: RGBA8 pixels packed as uint32 (ABGR on little-endian).
+// The kernel reads src and dst, composites using PSDTool's 3-component alpha
+// blending, and writes the result to the output buffer.
+
+kernel void psdComposite(
+    device const uchar4* src      [[buffer(0)]],
+    device const uchar4* dst      [[buffer(1)]],
+    device uchar4*       output   [[buffer(2)]],
+    constant CompositeParams& params [[buffer(3)]],
+    uint2 gid [[thread_position_in_grid]]
+) {
+    if (gid.x >= params.width || gid.y >= params.height) return;
+
+    uint idx = gid.y * params.width + gid.x;
+
+    // Read RGBA pixels and convert to float [0,1]
+    float4 srcPixel = float4(src[idx]) / 255.0;
+    float4 dstPixel = float4(dst[idx]) / 255.0;
+
+    // Source and dest are straight alpha
+    float sa = srcPixel.a;
+    float da = dstPixel.a;
+
+    if (sa < 1.0 / 255.0) {
+        output[idx] = dst[idx];
+        return;
+    }
+
+    float3 sRgb = srcPixel.rgb;
+    float3 dRgb = dstPixel.rgb;
+
+    // PSDTool 3-component alpha compositing
+    float tmp = sa * params.opacity;
+    float a1 = tmp * da;           // blend result contribution
+    float a2 = tmp * (1.0 - da);  // source-only
+    float a3 = (1.0 - tmp) * da;  // dest-only
+    float a  = a1 + a2 + a3;
+
+    if (a < 1.0 / 255.0) {
+        output[idx] = uchar4(0);
+        return;
+    }
+
+    // Apply blend function
+    float3 blended = blendPixels(sRgb, dRgb, params.blendMode);
+
+    // Final composite
+    float3 outRgb = (blended * a1 + sRgb * a2 + dRgb * a3) / a;
+    outRgb = clamp(outRgb, 0.0, 1.0);
+
+    // Write straight-alpha RGBA output
+    output[idx] = uchar4(
+        uchar(outRgb.r * 255.0 + 0.5),
+        uchar(outRgb.g * 255.0 + 0.5),
+        uchar(outRgb.b * 255.0 + 0.5),
+        uchar(a * 255.0 + 0.5)
+    );
+}

--- a/ios/dart_psd_tool.podspec
+++ b/ios/dart_psd_tool.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name             = 'dart_psd_tool'
+  s.version          = '0.1.0'
+  s.summary          = 'Metal GPU compositor for PSD blending.'
+  s.description      = 'Native Metal compute shader plugin for PSDTool-compatible compositing.'
+  s.homepage         = 'https://github.com/sawarae/dart-psd-tool'
+  s.license          = { :type => 'MIT', :file => '../LICENSE' }
+  s.author           = { 'sawarae' => 'sawarae' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*.{swift,metal}'
+  s.dependency 'Flutter'
+  s.platform         = :ios, '13.0'
+  s.swift_version    = '5.0'
+
+  s.pod_target_xcconfig = {
+    'MTL_COMPILER_FLAGS' => '-std=metal2.0',
+    'DEFINES_MODULE' => 'YES',
+  }
+end

--- a/lib/dart_psd_tool.dart
+++ b/lib/dart_psd_tool.dart
@@ -1,6 +1,6 @@
 /// PSDTool-compatible PSD reader and compositor library.
 ///
-/// Provides both software (CPU) and GPU compositing that matches
+/// Provides software (CPU), GLSL GPU, and Metal GPU compositing that matches
 /// PSDTool Go's output exactly using 3-component alpha blending.
 library dart_psd_tool;
 
@@ -9,3 +9,4 @@ export 'src/psd_reader.dart';
 export 'src/blend_modes.dart';
 export 'src/compositor.dart';
 export 'src/canvas_compositor.dart';
+export 'src/metal_compositor.dart';

--- a/lib/src/metal_compositor.dart
+++ b/lib/src/metal_compositor.dart
@@ -1,0 +1,297 @@
+import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:image/image.dart' as img;
+
+import 'psd_layer_node.dart';
+
+/// PSDTool-compatible Metal GPU compositor.
+///
+/// Uses Apple Metal compute shaders on macOS and iOS to perform PSDTool's
+/// 3-component alpha compositing on the GPU. Falls back gracefully when
+/// Metal is not available (e.g. on Android, Web, or simulators without GPU).
+///
+/// All 26 PSD blend modes are supported with output matching the CPU
+/// [PsdCompositor] and GLSL [PsdCanvasCompositor].
+class PsdMetalCompositor {
+  static const MethodChannel _channel = MethodChannel('dart_psd_tool/metal');
+
+  bool _initialized = false;
+
+  PsdMetalCompositor._();
+
+  /// Check if Metal compositing is available on the current platform.
+  ///
+  /// Returns true on macOS and iOS devices with Metal support.
+  /// Returns false on Android, Web, Linux, Windows, and simulators
+  /// without GPU access.
+  static Future<bool> get isAvailable async {
+    if (!_isPlatformSupported) return false;
+    try {
+      final result = await _channel.invokeMethod<bool>('isAvailable');
+      return result ?? false;
+    } on MissingPluginException {
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Whether the current platform could potentially support Metal.
+  static bool get _isPlatformSupported {
+    return defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.iOS;
+  }
+
+  /// Create and initialize a Metal compositor.
+  ///
+  /// Throws [MetalNotAvailableException] if Metal is not supported on the
+  /// current device. Use [isAvailable] to check before calling.
+  static Future<PsdMetalCompositor> create() async {
+    final compositor = PsdMetalCompositor._();
+    try {
+      await _channel.invokeMethod<bool>('initialize');
+      compositor._initialized = true;
+    } on PlatformException catch (e) {
+      throw MetalNotAvailableException(e.message ?? 'Metal initialization failed');
+    } on MissingPluginException {
+      throw MetalNotAvailableException(
+          'Metal plugin not registered. Ensure the plugin is included in your app.');
+    }
+    return compositor;
+  }
+
+  /// Blend mode name to shader index mapping.
+  static const _blendModeIndex = <String, int>{
+    'Normal': 0,
+    'Multiply': 1,
+    'Screen': 2,
+    'Overlay': 3,
+    'Darken': 4,
+    'Lighten': 5,
+    'ColorDodge': 6,
+    'ColorBurn': 7,
+    'HardLight': 8,
+    'SoftLight': 9,
+    'Difference': 10,
+    'Subtract': 11,
+    'LinearDodge': 12,
+    'Divide': 13,
+    'Exclusion': 14,
+    'LinearBurn': 15,
+    'VividLight': 16,
+    'LinearLight': 17,
+    'PinLight': 18,
+    'HardMix': 19,
+    'DarkerColor': 20,
+    'LighterColor': 21,
+    'Hue': 22,
+    'Saturation': 23,
+    'Color': 24,
+    'Luminosity': 25,
+  };
+
+  /// Composite [src] onto [dst] using PSDTool-accurate blending via Metal GPU.
+  ///
+  /// Both images must have the same dimensions. Returns a new composited image.
+  /// The blend operation uses PSDTool's 3-component alpha algorithm, producing
+  /// results that match the CPU [PsdCompositor] and GLSL [PsdCanvasCompositor].
+  ///
+  /// Throws [StateError] if the compositor has not been initialized or has
+  /// been disposed.
+  Future<img.Image> composite(
+    img.Image src,
+    img.Image dst, {
+    double opacity = 1.0,
+    String blendMode = 'Normal',
+  }) async {
+    if (!_initialized) {
+      throw StateError('Metal compositor not initialized or already disposed');
+    }
+
+    final width = dst.width;
+    final height = dst.height;
+
+    // Extract straight-alpha RGBA bytes
+    final srcBytes = _imageToRgbaBytes(src, width, height);
+    final dstBytes = _imageToRgbaBytes(dst, width, height);
+
+    final resultBytes = await _channel.invokeMethod<Uint8List>(
+      'composite',
+      <String, dynamic>{
+        'src': srcBytes,
+        'dst': dstBytes,
+        'width': width,
+        'height': height,
+        'blendMode': _blendModeIndex[blendMode] ?? 0,
+        'opacity': opacity,
+      },
+    );
+
+    if (resultBytes == null) {
+      throw StateError('Metal compositor returned null result');
+    }
+
+    return _rgbaBytesToImage(resultBytes, width, height);
+  }
+
+  /// Composite [src] onto [dst] in place, modifying [dst].
+  ///
+  /// This is a convenience method matching the [PsdCompositor.composite]
+  /// signature. The [src] image is composited at [offsetX], [offsetY] within
+  /// [dst].
+  Future<void> compositeInPlace(
+    img.Image dst,
+    img.Image src, {
+    int offsetX = 0,
+    int offsetY = 0,
+    double opacity = 1.0,
+    String blendMode = 'Normal',
+  }) async {
+    if (!_initialized) {
+      throw StateError('Metal compositor not initialized or already disposed');
+    }
+
+    // If src is smaller than dst, we need to create a full-size src buffer
+    // with the src image placed at the correct offset
+    final width = dst.width;
+    final height = dst.height;
+
+    final srcFull = img.Image(width: width, height: height, numChannels: 4)
+      ..clear(img.ColorRgba8(0, 0, 0, 0));
+
+    // Copy src pixels to the offset position
+    for (int sy = 0; sy < src.height; sy++) {
+      final dy = sy + offsetY;
+      if (dy < 0 || dy >= height) continue;
+      for (int sx = 0; sx < src.width; sx++) {
+        final dx = sx + offsetX;
+        if (dx < 0 || dx >= width) continue;
+        final p = src.getPixel(sx, sy);
+        srcFull.setPixelRgba(dx, dy, p.r.toInt(), p.g.toInt(), p.b.toInt(), p.a.toInt());
+      }
+    }
+
+    final result = await composite(srcFull, dst, opacity: opacity, blendMode: blendMode);
+
+    // Copy result back to dst
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        final p = result.getPixel(x, y);
+        dst.setPixelRgba(x, y, p.r.toInt(), p.g.toInt(), p.b.toInt(), p.a.toInt());
+      }
+    }
+  }
+
+  /// Render a PSD layer tree using Metal GPU compositing.
+  ///
+  /// Equivalent to [PsdCompositor.renderLayerTree] but uses the Metal GPU
+  /// for compositing operations.
+  Future<img.Image> renderLayerTree(
+    List<PsdLayerNode> layers,
+    int canvasW,
+    int canvasH, {
+    bool Function(PsdLayerNode)? visibilityFilter,
+  }) async {
+    final canvas = img.Image(width: canvasW, height: canvasH, numChannels: 4)
+      ..clear(img.ColorRgba8(0, 0, 0, 0));
+
+    await _renderNodes(canvas, layers, canvasW, canvasH, visibilityFilter);
+    return canvas;
+  }
+
+  Future<void> _renderNodes(
+    img.Image canvas,
+    List<PsdLayerNode> nodes,
+    int canvasW,
+    int canvasH,
+    bool Function(PsdLayerNode)? filter,
+  ) async {
+    for (final node in nodes) {
+      final visible = filter != null ? filter(node) : node.psdVisible;
+      if (!visible) continue;
+
+      if (node.isGroup) {
+        final groupBuf =
+            img.Image(width: canvasW, height: canvasH, numChannels: 4)
+              ..clear(img.ColorRgba8(0, 0, 0, 0));
+        await _renderNodes(groupBuf, node.children, canvasW, canvasH, filter);
+        final result = await composite(
+          groupBuf,
+          canvas,
+          blendMode: node.blendMode == 'Normal' ? 'Normal' : node.blendMode,
+        );
+        // Copy result back to canvas
+        for (int y = 0; y < canvasH; y++) {
+          for (int x = 0; x < canvasW; x++) {
+            final p = result.getPixel(x, y);
+            canvas.setPixelRgba(x, y, p.r.toInt(), p.g.toInt(), p.b.toInt(), p.a.toInt());
+          }
+        }
+      } else if (node.pngBytes != null) {
+        final layerImg = img.decodePng(node.pngBytes!);
+        if (layerImg != null) {
+          await compositeInPlace(
+            canvas,
+            layerImg,
+            offsetX: node.left,
+            offsetY: node.top,
+            blendMode: node.blendMode,
+          );
+        }
+      }
+    }
+  }
+
+  /// Release native Metal resources.
+  ///
+  /// After calling dispose, no further compositing operations can be performed.
+  Future<void> dispose() async {
+    if (_initialized) {
+      _initialized = false;
+      try {
+        await _channel.invokeMethod<void>('dispose');
+      } catch (_) {
+        // Ignore errors during dispose
+      }
+    }
+  }
+
+  /// Convert an [img.Image] to straight-alpha RGBA bytes, padded to the
+  /// given [width] x [height].
+  static Uint8List _imageToRgbaBytes(img.Image image, int width, int height) {
+    final bytes = Uint8List(width * height * 4);
+    for (int y = 0; y < image.height && y < height; y++) {
+      for (int x = 0; x < image.width && x < width; x++) {
+        final p = image.getPixel(x, y);
+        final i = (y * width + x) * 4;
+        bytes[i] = p.r.toInt();
+        bytes[i + 1] = p.g.toInt();
+        bytes[i + 2] = p.b.toInt();
+        bytes[i + 3] = p.a.toInt();
+      }
+    }
+    return bytes;
+  }
+
+  /// Convert straight-alpha RGBA bytes back to an [img.Image].
+  static img.Image _rgbaBytesToImage(Uint8List bytes, int width, int height) {
+    final image = img.Image(width: width, height: height, numChannels: 4);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        final i = (y * width + x) * 4;
+        image.setPixelRgba(x, y, bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]);
+      }
+    }
+    return image;
+  }
+}
+
+/// Exception thrown when Metal is not available on the current device.
+class MetalNotAvailableException implements Exception {
+  final String message;
+  MetalNotAvailableException(this.message);
+
+  @override
+  String toString() => 'MetalNotAvailableException: $message';
+}

--- a/macos/Classes/DartPsdToolPlugin.swift
+++ b/macos/Classes/DartPsdToolPlugin.swift
@@ -1,0 +1,92 @@
+import Cocoa
+import FlutterMacOS
+
+/// Flutter plugin for PSD Metal compositing on macOS.
+public class DartPsdToolPlugin: NSObject, FlutterPlugin {
+    private var compositor: PsdMetalCompositor?
+
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: "dart_psd_tool/metal",
+            binaryMessenger: registrar.messenger
+        )
+        let instance = DartPsdToolPlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "isAvailable":
+            result(PsdMetalCompositor.isAvailable)
+
+        case "initialize":
+            do {
+                compositor = try PsdMetalCompositor()
+                result(true)
+            } catch {
+                result(FlutterError(
+                    code: "METAL_INIT_FAILED",
+                    message: error.localizedDescription,
+                    details: nil
+                ))
+            }
+
+        case "composite":
+            guard let compositor = compositor else {
+                result(FlutterError(
+                    code: "NOT_INITIALIZED",
+                    message: "Metal compositor not initialized. Call initialize() first.",
+                    details: nil
+                ))
+                return
+            }
+
+            guard let args = call.arguments as? [String: Any],
+                  let srcBytes = args["src"] as? FlutterStandardTypedData,
+                  let dstBytes = args["dst"] as? FlutterStandardTypedData,
+                  let width = args["width"] as? Int,
+                  let height = args["height"] as? Int,
+                  let blendMode = args["blendMode"] as? Int,
+                  let opacity = args["opacity"] as? Double else {
+                result(FlutterError(
+                    code: "INVALID_ARGS",
+                    message: "Missing or invalid arguments",
+                    details: nil
+                ))
+                return
+            }
+
+            // Run compositing on a background queue to avoid blocking the platform thread
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let output = try compositor.composite(
+                        srcBytes: srcBytes.data,
+                        dstBytes: dstBytes.data,
+                        width: width,
+                        height: height,
+                        blendMode: blendMode,
+                        opacity: Float(opacity)
+                    )
+                    DispatchQueue.main.async {
+                        result(FlutterStandardTypedData(bytes: output))
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        result(FlutterError(
+                            code: "COMPOSITE_FAILED",
+                            message: error.localizedDescription,
+                            details: nil
+                        ))
+                    }
+                }
+            }
+
+        case "dispose":
+            compositor = nil
+            result(nil)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+}

--- a/macos/Classes/PsdMetalCompositor.swift
+++ b/macos/Classes/PsdMetalCompositor.swift
@@ -1,0 +1,169 @@
+import Cocoa
+import Metal
+import FlutterMacOS
+
+/// Native Metal compositor for PSD blending.
+///
+/// Uses a Metal compute shader to perform PSDTool-compatible 3-component
+/// alpha compositing on the GPU. All 26 PSD blend modes are supported.
+public class PsdMetalCompositor {
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let pipelineState: MTLComputePipelineState
+
+    init() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw MetalError.noDevice
+        }
+        self.device = device
+
+        guard let commandQueue = device.makeCommandQueue() else {
+            throw MetalError.noCommandQueue
+        }
+        self.commandQueue = commandQueue
+
+        // Load the Metal shader library from the plugin bundle
+        let bundle = Bundle(for: PsdMetalCompositor.self)
+        guard let libraryURL = bundle.url(forResource: "default", withExtension: "metallib")
+              ?? bundle.url(forResource: "psd_composite", withExtension: "metallib") else {
+            // Fallback: compile from source at runtime
+            guard let metalURL = bundle.url(forResource: "psd_composite", withExtension: "metal") else {
+                throw MetalError.noShaderSource
+            }
+            let source = try String(contentsOf: metalURL)
+            let library = try device.makeLibrary(source: source, options: nil)
+            guard let function = library.makeFunction(name: "psdComposite") else {
+                throw MetalError.noFunction
+            }
+            self.pipelineState = try device.makeComputePipelineState(function: function)
+            return
+        }
+        let library = try device.makeLibrary(URL: libraryURL)
+        guard let function = library.makeFunction(name: "psdComposite") else {
+            throw MetalError.noFunction
+        }
+        self.pipelineState = try device.makeComputePipelineState(function: function)
+    }
+
+    /// Composite src onto dst using the specified blend mode.
+    ///
+    /// - Parameters:
+    ///   - srcBytes: Source image RGBA pixel data (straight alpha)
+    ///   - dstBytes: Destination image RGBA pixel data (straight alpha)
+    ///   - width: Image width in pixels
+    ///   - height: Image height in pixels
+    ///   - blendMode: Blend mode index (0=Normal .. 25=Luminosity)
+    ///   - opacity: Opacity multiplier (0.0 - 1.0)
+    /// - Returns: Composited RGBA pixel data (straight alpha)
+    func composite(
+        srcBytes: Data,
+        dstBytes: Data,
+        width: Int,
+        height: Int,
+        blendMode: Int,
+        opacity: Float
+    ) throws -> Data {
+        let pixelCount = width * height
+        let bufferSize = pixelCount * 4
+
+        guard srcBytes.count >= bufferSize, dstBytes.count >= bufferSize else {
+            throw MetalError.invalidBufferSize
+        }
+
+        // Create Metal buffers
+        guard let srcBuffer = device.makeBuffer(bytes: (srcBytes as NSData).bytes,
+                                                 length: bufferSize,
+                                                 options: .storageModeShared),
+              let dstBuffer = device.makeBuffer(bytes: (dstBytes as NSData).bytes,
+                                                 length: bufferSize,
+                                                 options: .storageModeShared),
+              let outBuffer = device.makeBuffer(length: bufferSize,
+                                                options: .storageModeShared) else {
+            throw MetalError.bufferCreationFailed
+        }
+
+        // Set up params
+        var params = CompositeParams(
+            width: UInt32(width),
+            height: UInt32(height),
+            opacity: opacity,
+            blendMode: Int32(blendMode)
+        )
+
+        guard let paramsBuffer = device.makeBuffer(bytes: &params,
+                                                    length: MemoryLayout<CompositeParams>.size,
+                                                    options: .storageModeShared) else {
+            throw MetalError.bufferCreationFailed
+        }
+
+        // Encode and dispatch
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else {
+            throw MetalError.encodingFailed
+        }
+
+        encoder.setComputePipelineState(pipelineState)
+        encoder.setBuffer(srcBuffer, offset: 0, index: 0)
+        encoder.setBuffer(dstBuffer, offset: 0, index: 1)
+        encoder.setBuffer(outBuffer, offset: 0, index: 2)
+        encoder.setBuffer(paramsBuffer, offset: 0, index: 3)
+
+        let threadgroupSize = MTLSize(
+            width: min(16, pipelineState.maxTotalThreadsPerThreadgroup),
+            height: min(16, pipelineState.maxTotalThreadsPerThreadgroup / 16),
+            depth: 1
+        )
+        let gridSize = MTLSize(width: width, height: height, depth: 1)
+
+        encoder.dispatchThreads(gridSize, threadsPerThreadgroup: threadgroupSize)
+        encoder.endEncoding()
+
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        if let error = commandBuffer.error {
+            throw MetalError.executionFailed(error.localizedDescription)
+        }
+
+        // Read output
+        let outputPointer = outBuffer.contents().bindMemory(to: UInt8.self, capacity: bufferSize)
+        return Data(bytes: outputPointer, count: bufferSize)
+    }
+
+    /// Check if Metal is available on this device.
+    static var isAvailable: Bool {
+        return MTLCreateSystemDefaultDevice() != nil
+    }
+}
+
+// Mirror the struct layout from the Metal shader
+struct CompositeParams {
+    var width: UInt32
+    var height: UInt32
+    var opacity: Float
+    var blendMode: Int32
+}
+
+enum MetalError: Error, LocalizedError {
+    case noDevice
+    case noCommandQueue
+    case noShaderSource
+    case noFunction
+    case invalidBufferSize
+    case bufferCreationFailed
+    case encodingFailed
+    case executionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noDevice: return "No Metal device available"
+        case .noCommandQueue: return "Failed to create command queue"
+        case .noShaderSource: return "Metal shader source not found"
+        case .noFunction: return "Metal function 'psdComposite' not found"
+        case .invalidBufferSize: return "Buffer size does not match dimensions"
+        case .bufferCreationFailed: return "Failed to create Metal buffer"
+        case .encodingFailed: return "Failed to create command encoder"
+        case .executionFailed(let msg): return "Metal execution failed: \(msg)"
+        }
+    }
+}

--- a/macos/Classes/psd_composite.metal
+++ b/macos/Classes/psd_composite.metal
@@ -1,0 +1,264 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// ── Per-channel blend functions ──
+
+static float3 blendNormal(float3 s, float3 d)     { return s; }
+static float3 blendMultiply(float3 s, float3 d)   { return s * d; }
+static float3 blendScreen(float3 s, float3 d)     { return s + d - s * d; }
+
+static float3 blendOverlay(float3 s, float3 d) {
+    return mix(
+        2.0 * s * d,
+        1.0 - 2.0 * (1.0 - s) * (1.0 - d),
+        step(0.5, d)
+    );
+}
+
+static float3 blendDarken(float3 s, float3 d)     { return min(s, d); }
+static float3 blendLighten(float3 s, float3 d)    { return max(s, d); }
+
+static float3 blendColorDodge(float3 s, float3 d) {
+    return mix(
+        mix(min(float3(1.0), d / max(1.0 - s, 1.0 / 255.0)), float3(1.0), step(1.0, s)),
+        float3(0.0),
+        step(d, float3(0.0))
+    );
+}
+
+static float3 blendColorBurn(float3 s, float3 d) {
+    return mix(
+        mix(1.0 - min(float3(1.0), (1.0 - d) / max(s, 1.0 / 255.0)), float3(0.0), step(s, float3(0.0))),
+        float3(1.0),
+        step(1.0, d)
+    );
+}
+
+static float3 blendHardLight(float3 s, float3 d) {
+    return mix(
+        2.0 * s * d,
+        1.0 - 2.0 * (1.0 - s) * (1.0 - d),
+        step(0.5, s)
+    );
+}
+
+static float3 blendSoftLight(float3 s, float3 d) {
+    float3 dd = mix(
+        sqrt(d),
+        ((16.0 * d - 12.0) * d + 4.0) * d,
+        step(d, float3(0.25))
+    );
+    return mix(
+        d - (1.0 - 2.0 * s) * d * (1.0 - d),
+        d + (2.0 * s - 1.0) * (dd - d),
+        step(0.5, s)
+    );
+}
+
+static float3 blendDifference(float3 s, float3 d) { return abs(s - d); }
+static float3 blendSubtract(float3 s, float3 d)   { return max(float3(0.0), d - s); }
+static float3 blendLinearDodge(float3 s, float3 d) { return min(float3(1.0), s + d); }
+
+static float3 blendDivide(float3 s, float3 d) {
+    float3 eps = float3(1.0 / 255.0);
+    return mix(
+        min(float3(1.0), d / max(s, eps)),
+        mix(float3(0.0), float3(1.0), step(eps, d)),
+        step(s, float3(0.0))
+    );
+}
+
+static float3 blendExclusion(float3 s, float3 d) { return s + d - 2.0 * s * d; }
+static float3 blendLinearBurn(float3 s, float3 d) { return max(float3(0.0), s + d - 1.0); }
+
+static float3 blendVividLight(float3 s, float3 d) {
+    return mix(
+        blendColorBurn(2.0 * s, d),
+        blendColorDodge(2.0 * s - 1.0, d),
+        step(0.5, s)
+    );
+}
+
+static float3 blendLinearLight(float3 s, float3 d) { return clamp(d + 2.0 * s - 1.0, 0.0, 1.0); }
+
+static float3 blendPinLight(float3 s, float3 d) {
+    return mix(
+        min(d, 2.0 * s),
+        max(d, 2.0 * s - 1.0),
+        step(0.5, s)
+    );
+}
+
+static float3 blendHardMix(float3 s, float3 d) {
+    return step(0.5, blendVividLight(s, d));
+}
+
+// ── HSL helper functions (W3C Compositing and Blending Level 1) ──
+
+static float lum(float3 c) { return 0.299 * c.r + 0.587 * c.g + 0.114 * c.b; }
+
+static float sat(float3 c) { return max(c.r, max(c.g, c.b)) - min(c.r, min(c.g, c.b)); }
+
+static float3 clipColor(float3 c) {
+    float l = lum(c);
+    float n = min(c.r, min(c.g, c.b));
+    float x = max(c.r, max(c.g, c.b));
+    if (n < 0.0) {
+        c = l + (c - l) * l / (l - n);
+    }
+    if (x > 1.0) {
+        c = l + (c - l) * (1.0 - l) / (x - l);
+    }
+    return clamp(c, 0.0, 1.0);
+}
+
+static float3 setLum(float3 c, float l) {
+    float d = l - lum(c);
+    return clipColor(c + d);
+}
+
+static float3 setSat(float3 c, float s) {
+    float cmin = min(c.r, min(c.g, c.b));
+    float cmax = max(c.r, max(c.g, c.b));
+
+    if (cmax > cmin) {
+        return (c - cmin) * s / (cmax - cmin);
+    }
+    return float3(0.0);
+}
+
+// ── Per-pixel blend modes (index 20-25) ──
+
+static float3 blendDarkerColor(float3 s, float3 d) {
+    return lum(s) < lum(d) ? s : d;
+}
+
+static float3 blendLighterColor(float3 s, float3 d) {
+    return lum(s) > lum(d) ? s : d;
+}
+
+static float3 blendHue(float3 s, float3 d) {
+    return setLum(setSat(s, sat(d)), lum(d));
+}
+
+static float3 blendSaturation(float3 s, float3 d) {
+    return setLum(setSat(d, sat(s)), lum(d));
+}
+
+static float3 blendColor(float3 s, float3 d) {
+    return setLum(s, lum(d));
+}
+
+static float3 blendLuminosity(float3 s, float3 d) {
+    return setLum(d, lum(s));
+}
+
+// ── Dispatch blend mode by index ──
+
+static float3 blendPixels(float3 s, float3 d, int mode) {
+    switch (mode) {
+        case 0:  return blendNormal(s, d);
+        case 1:  return blendMultiply(s, d);
+        case 2:  return blendScreen(s, d);
+        case 3:  return blendOverlay(s, d);
+        case 4:  return blendDarken(s, d);
+        case 5:  return blendLighten(s, d);
+        case 6:  return blendColorDodge(s, d);
+        case 7:  return blendColorBurn(s, d);
+        case 8:  return blendHardLight(s, d);
+        case 9:  return blendSoftLight(s, d);
+        case 10: return blendDifference(s, d);
+        case 11: return blendSubtract(s, d);
+        case 12: return blendLinearDodge(s, d);
+        case 13: return blendDivide(s, d);
+        case 14: return blendExclusion(s, d);
+        case 15: return blendLinearBurn(s, d);
+        case 16: return blendVividLight(s, d);
+        case 17: return blendLinearLight(s, d);
+        case 18: return blendPinLight(s, d);
+        case 19: return blendHardMix(s, d);
+        case 20: return blendDarkerColor(s, d);
+        case 21: return blendLighterColor(s, d);
+        case 22: return blendHue(s, d);
+        case 23: return blendSaturation(s, d);
+        case 24: return blendColor(s, d);
+        case 25: return blendLuminosity(s, d);
+        default: return blendNormal(s, d);
+    }
+}
+
+// ── Uniforms ──
+
+struct CompositeParams {
+    uint width;
+    uint height;
+    float opacity;
+    int blendMode;  // 0=Normal .. 25=Luminosity
+};
+
+// ── Un-premultiply alpha ──
+
+static float4 unpremultiply(float4 c) {
+    if (c.a < 1.0 / 255.0) return float4(0.0);
+    return float4(c.rgb / c.a, c.a);
+}
+
+// ── Compute kernel ──
+// Input/output buffers: RGBA8 pixels packed as uint32 (ABGR on little-endian).
+// The kernel reads src and dst, composites using PSDTool's 3-component alpha
+// blending, and writes the result to the output buffer.
+
+kernel void psdComposite(
+    device const uchar4* src      [[buffer(0)]],
+    device const uchar4* dst      [[buffer(1)]],
+    device uchar4*       output   [[buffer(2)]],
+    constant CompositeParams& params [[buffer(3)]],
+    uint2 gid [[thread_position_in_grid]]
+) {
+    if (gid.x >= params.width || gid.y >= params.height) return;
+
+    uint idx = gid.y * params.width + gid.x;
+
+    // Read RGBA pixels and convert to float [0,1]
+    float4 srcPixel = float4(src[idx]) / 255.0;
+    float4 dstPixel = float4(dst[idx]) / 255.0;
+
+    // Source and dest are straight alpha
+    float sa = srcPixel.a;
+    float da = dstPixel.a;
+
+    if (sa < 1.0 / 255.0) {
+        output[idx] = dst[idx];
+        return;
+    }
+
+    float3 sRgb = srcPixel.rgb;
+    float3 dRgb = dstPixel.rgb;
+
+    // PSDTool 3-component alpha compositing
+    float tmp = sa * params.opacity;
+    float a1 = tmp * da;           // blend result contribution
+    float a2 = tmp * (1.0 - da);  // source-only
+    float a3 = (1.0 - tmp) * da;  // dest-only
+    float a  = a1 + a2 + a3;
+
+    if (a < 1.0 / 255.0) {
+        output[idx] = uchar4(0);
+        return;
+    }
+
+    // Apply blend function
+    float3 blended = blendPixels(sRgb, dRgb, params.blendMode);
+
+    // Final composite
+    float3 outRgb = (blended * a1 + sRgb * a2 + dRgb * a3) / a;
+    outRgb = clamp(outRgb, 0.0, 1.0);
+
+    // Write straight-alpha RGBA output
+    output[idx] = uchar4(
+        uchar(outRgb.r * 255.0 + 0.5),
+        uchar(outRgb.g * 255.0 + 0.5),
+        uchar(outRgb.b * 255.0 + 0.5),
+        uchar(a * 255.0 + 0.5)
+    );
+}

--- a/macos/dart_psd_tool.podspec
+++ b/macos/dart_psd_tool.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name             = 'dart_psd_tool'
+  s.version          = '0.1.0'
+  s.summary          = 'Metal GPU compositor for PSD blending.'
+  s.description      = 'Native Metal compute shader plugin for PSDTool-compatible compositing.'
+  s.homepage         = 'https://github.com/sawarae/dart-psd-tool'
+  s.license          = { :type => 'MIT', :file => '../LICENSE' }
+  s.author           = { 'sawarae' => 'sawarae' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*.{swift,metal}'
+  s.dependency 'FlutterMacOS'
+  s.platform         = :osx, '10.15'
+  s.swift_version    = '5.0'
+
+  # Metal shader compilation
+  s.pod_target_xcconfig = {
+    'MTL_COMPILER_FLAGS' => '-std=metal2.0',
+    'DEFINES_MODULE' => 'YES',
+  }
+end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,5 +22,11 @@ dependency_overrides:
   archive: ^4.0.0
 
 flutter:
+  plugin:
+    platforms:
+      macos:
+        pluginClass: DartPsdToolPlugin
+      ios:
+        pluginClass: DartPsdToolPlugin
   shaders:
     - shaders/psd_composite.frag

--- a/test/metal_compositor_test.dart
+++ b/test/metal_compositor_test.dart
@@ -1,0 +1,326 @@
+import 'dart:typed_data';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:dart_psd_tool/dart_psd_tool.dart';
+
+/// Mock Metal MethodChannel handler that simulates Metal compositing
+/// using the CPU compositor for verification in unit tests.
+///
+/// This allows testing the Dart-side API, serialization, and blend mode
+/// mapping without requiring actual Metal hardware.
+class MockMetalHandler {
+  bool _initialized = false;
+
+  Future<dynamic> handle(MethodCall call) async {
+    switch (call.method) {
+      case 'isAvailable':
+        return true;
+      case 'initialize':
+        _initialized = true;
+        return true;
+      case 'composite':
+        if (!_initialized) {
+          throw PlatformException(code: 'NOT_INITIALIZED');
+        }
+        final args = call.arguments as Map<dynamic, dynamic>;
+        final srcBytes = args['src'] as Uint8List;
+        final dstBytes = args['dst'] as Uint8List;
+        final width = args['width'] as int;
+        final height = args['height'] as int;
+        final blendModeIndex = args['blendMode'] as int;
+        final opacity = args['opacity'] as double;
+
+        // Reverse map blend mode index to name
+        final blendModeName = _blendModeNames[blendModeIndex] ?? 'Normal';
+
+        // Reconstruct images from bytes
+        final src = _bytesToImage(srcBytes, width, height);
+        final dst = _bytesToImage(dstBytes, width, height);
+
+        // Use CPU compositor for the actual blending
+        PsdCompositor.composite(dst, src,
+            blendMode: blendModeName, opacity: opacity);
+
+        // Return result as RGBA bytes
+        return _imageToBytes(dst);
+      case 'dispose':
+        _initialized = false;
+        return null;
+      default:
+        throw MissingPluginException();
+    }
+  }
+
+  static img.Image _bytesToImage(Uint8List bytes, int width, int height) {
+    final image = img.Image(width: width, height: height, numChannels: 4);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        final i = (y * width + x) * 4;
+        image.setPixelRgba(x, y, bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]);
+      }
+    }
+    return image;
+  }
+
+  static Uint8List _imageToBytes(img.Image image) {
+    final bytes = Uint8List(image.width * image.height * 4);
+    for (int y = 0; y < image.height; y++) {
+      for (int x = 0; x < image.width; x++) {
+        final p = image.getPixel(x, y);
+        final i = (y * image.width + x) * 4;
+        bytes[i] = p.r.toInt();
+        bytes[i + 1] = p.g.toInt();
+        bytes[i + 2] = p.b.toInt();
+        bytes[i + 3] = p.a.toInt();
+      }
+    }
+    return bytes;
+  }
+
+  static const _blendModeNames = <int, String>{
+    0: 'Normal',
+    1: 'Multiply',
+    2: 'Screen',
+    3: 'Overlay',
+    4: 'Darken',
+    5: 'Lighten',
+    6: 'ColorDodge',
+    7: 'ColorBurn',
+    8: 'HardLight',
+    9: 'SoftLight',
+    10: 'Difference',
+    11: 'Subtract',
+    12: 'LinearDodge',
+    13: 'Divide',
+    14: 'Exclusion',
+    15: 'LinearBurn',
+    16: 'VividLight',
+    17: 'LinearLight',
+    18: 'PinLight',
+    19: 'HardMix',
+    20: 'DarkerColor',
+    21: 'LighterColor',
+    22: 'Hue',
+    23: 'Saturation',
+    24: 'Color',
+    25: 'Luminosity',
+  };
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockMetalHandler mockHandler;
+
+  setUp(() {
+    mockHandler = MockMetalHandler();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('dart_psd_tool/metal'),
+      mockHandler.handle,
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('dart_psd_tool/metal'),
+      null,
+    );
+  });
+
+  group('PsdMetalCompositor', () {
+    test('isAvailable returns true with mock', () async {
+      expect(await PsdMetalCompositor.isAvailable, isTrue);
+    });
+
+    test('create initializes successfully', () async {
+      final compositor = await PsdMetalCompositor.create();
+      await compositor.dispose();
+    });
+
+    test('composite normal blend - opaque over transparent', () async {
+      final compositor = await PsdMetalCompositor.create();
+
+      final src = img.Image(width: 4, height: 4, numChannels: 4)
+        ..clear(img.ColorRgba8(255, 0, 0, 255));
+      final dst = img.Image(width: 4, height: 4, numChannels: 4)
+        ..clear(img.ColorRgba8(0, 0, 0, 0));
+
+      final result = await compositor.composite(src, dst);
+
+      final p = result.getPixel(0, 0);
+      expect(p.r.toInt(), 255);
+      expect(p.g.toInt(), 0);
+      expect(p.b.toInt(), 0);
+      expect(p.a.toInt(), 255);
+
+      await compositor.dispose();
+    });
+
+    test('composite multiply blend mode', () async {
+      final compositor = await PsdMetalCompositor.create();
+
+      final src = img.Image(width: 2, height: 2, numChannels: 4)
+        ..clear(img.ColorRgba8(128, 64, 32, 255));
+      final dst = img.Image(width: 2, height: 2, numChannels: 4)
+        ..clear(img.ColorRgba8(255, 255, 255, 255));
+
+      final result =
+          await compositor.composite(src, dst, blendMode: 'Multiply');
+
+      final p = result.getPixel(0, 0);
+      expect(p.r.toInt(), closeTo(128, 1));
+      expect(p.g.toInt(), closeTo(64, 1));
+      expect(p.b.toInt(), closeTo(32, 1));
+
+      await compositor.dispose();
+    });
+
+    test('composite screen blend mode', () async {
+      final compositor = await PsdMetalCompositor.create();
+
+      final src = img.Image(width: 1, height: 1, numChannels: 4);
+      src.setPixelRgba(0, 0, 128, 128, 128, 255);
+      final dst = img.Image(width: 1, height: 1, numChannels: 4);
+      dst.setPixelRgba(0, 0, 128, 128, 128, 255);
+
+      final result = await compositor.composite(src, dst, blendMode: 'Screen');
+
+      final p = result.getPixel(0, 0);
+      expect(p.r.toInt(), closeTo(192, 1));
+
+      await compositor.dispose();
+    });
+
+    test('compositeInPlace modifies destination', () async {
+      final compositor = await PsdMetalCompositor.create();
+
+      final dst = img.Image(width: 4, height: 4, numChannels: 4)
+        ..clear(img.ColorRgba8(0, 0, 0, 0));
+      final src = img.Image(width: 2, height: 2, numChannels: 4)
+        ..clear(img.ColorRgba8(255, 0, 0, 255));
+
+      await compositor.compositeInPlace(dst, src, offsetX: 1, offsetY: 1);
+
+      // Source pixel should be composited at offset
+      final p = dst.getPixel(1, 1);
+      expect(p.r.toInt(), 255);
+      expect(p.a.toInt(), 255);
+
+      // Outside source area should remain transparent
+      expect(dst.getPixel(0, 0).a.toInt(), 0);
+
+      await compositor.dispose();
+    });
+
+    test('renderLayerTree renders visible layers', () async {
+      final compositor = await PsdMetalCompositor.create();
+
+      final redPng = img.encodePng(
+        img.Image(width: 2, height: 2, numChannels: 4)
+          ..clear(img.ColorRgba8(255, 0, 0, 255)),
+      );
+
+      final layers = [
+        PsdLayerNode(
+          name: 'red',
+          isGroup: false,
+          isDefault: false,
+          isVariant: false,
+          psdVisible: true,
+          left: 0,
+          top: 0,
+          right: 2,
+          bottom: 2,
+          pngBytes: redPng,
+        ),
+      ];
+
+      final result = await compositor.renderLayerTree(layers, 4, 4);
+      expect(result.width, 4);
+      expect(result.height, 4);
+
+      final p = result.getPixel(0, 0);
+      expect(p.r.toInt(), 255);
+      expect(p.a.toInt(), 255);
+
+      expect(result.getPixel(3, 3).a.toInt(), 0);
+
+      await compositor.dispose();
+    });
+
+    test('renderLayerTree skips invisible layers', () async {
+      final compositor = await PsdMetalCompositor.create();
+
+      final redPng = img.encodePng(
+        img.Image(width: 2, height: 2, numChannels: 4)
+          ..clear(img.ColorRgba8(255, 0, 0, 255)),
+      );
+
+      final layers = [
+        PsdLayerNode(
+          name: 'hidden',
+          isGroup: false,
+          isDefault: false,
+          isVariant: false,
+          psdVisible: false,
+          left: 0,
+          top: 0,
+          right: 2,
+          bottom: 2,
+          pngBytes: redPng,
+        ),
+      ];
+
+      final result = await compositor.renderLayerTree(layers, 4, 4);
+      expect(result.getPixel(0, 0).a.toInt(), 0);
+
+      await compositor.dispose();
+    });
+
+    test('dispose prevents further operations', () async {
+      final compositor = await PsdMetalCompositor.create();
+      await compositor.dispose();
+
+      final src = img.Image(width: 2, height: 2, numChannels: 4)
+        ..clear(img.ColorRgba8(255, 0, 0, 255));
+      final dst = img.Image(width: 2, height: 2, numChannels: 4)
+        ..clear(img.ColorRgba8(0, 0, 0, 0));
+
+      expect(
+        () => compositor.composite(src, dst),
+        throwsStateError,
+      );
+    });
+
+    test('all blend modes are mapped', () async {
+      // Verify all 26 blend modes have valid index mappings
+      const allModes = [
+        'Normal', 'Multiply', 'Screen', 'Overlay',
+        'Darken', 'Lighten', 'ColorDodge', 'ColorBurn',
+        'HardLight', 'SoftLight', 'Difference', 'Subtract',
+        'LinearDodge', 'Divide', 'Exclusion', 'LinearBurn',
+        'VividLight', 'LinearLight', 'PinLight', 'HardMix',
+        'DarkerColor', 'LighterColor',
+        'Hue', 'Saturation', 'Color', 'Luminosity',
+      ];
+
+      final compositor = await PsdMetalCompositor.create();
+
+      final src = img.Image(width: 1, height: 1, numChannels: 4);
+      src.setPixelRgba(0, 0, 128, 64, 32, 200);
+      final dst = img.Image(width: 1, height: 1, numChannels: 4);
+      dst.setPixelRgba(0, 0, 200, 100, 50, 255);
+
+      for (final mode in allModes) {
+        // Should not throw for any supported blend mode
+        final result = await compositor.composite(src, dst, blendMode: mode);
+        expect(result.width, 1, reason: '$mode should produce valid output');
+      }
+
+      await compositor.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Introduce native Metal GPU compositing as an alternative to the existing
GLSL fragment shader pipeline. The Metal compute kernel supports all 26
PSD blend modes with PSDTool-compatible 3-component alpha compositing.

- Metal compute shader (psd_composite.metal) with full blend mode support
- macOS/iOS Flutter plugins with Swift bridge via MethodChannel
- PsdMetalCompositor Dart API with composite, compositeInPlace, renderLayerTree
- Graceful fallback: isAvailable check for non-Apple platforms
- Unit tests with mock MethodChannel handler

https://claude.ai/code/session_01AxcBGYGrkokCnNEGMK2BHb