### PR TITLE
fix: add srcStraightAlpha to PSD compositor

### DIFF
--- a/lib/src/canvas_compositor.dart
+++ b/lib/src/canvas_compositor.dart
@@ -70,14 +70,16 @@ class PsdCanvasCompositor {
     Rect bounds, {
     double opacity = 1.0,
     String blendMode = 'Normal',
+    bool srcStraightAlpha = false,
   }) {
     final shader = _program.fragmentShader();
 
-    // Uniforms: uSize (0,1), uOpacity (2), uBlendMode (3)
+    // Uniforms: uSize (0,1), uOpacity (2), uBlendMode (3), uSrcStraightAlpha (4)
     shader.setFloat(0, bounds.width);
     shader.setFloat(1, bounds.height);
     shader.setFloat(2, opacity);
     shader.setFloat(3, _blendModeIndex[blendMode] ?? 0);
+    shader.setFloat(4, srcStraightAlpha ? 1.0 : 0.0);
 
     // Samplers: uSrc (0), uDst (1)
     shader.setImageSampler(0, src);

--- a/shaders/psd_composite.frag
+++ b/shaders/psd_composite.frag
@@ -3,6 +3,7 @@
 uniform vec2 uSize;
 uniform float uOpacity;
 uniform float uBlendMode;  // 0=Normal .. 25=Luminosity
+uniform float uSrcStraightAlpha;  // 1.0 = source has straight alpha (skip unpremultiply)
 uniform sampler2D uSrc;
 uniform sampler2D uDst;
 
@@ -210,12 +211,14 @@ vec3 blendPixels(vec3 s, vec3 d, float mode) {
 void main() {
   vec2 uv = FlutterFragCoord().xy / uSize;
 
-  // Sample source and destination (premultiplied alpha from Flutter)
+  // Sample source and destination
   vec4 srcPre = texture(uSrc, uv);
   vec4 dstPre = texture(uDst, uv);
 
-  // Un-premultiply to get straight alpha
-  vec4 s = unpremultiply(srcPre);
+  // Un-premultiply to get straight alpha.
+  // Source may already be straight alpha when textures are loaded without
+  // premultiplication (matching inox2d's texture pipeline).
+  vec4 s = (uSrcStraightAlpha > 0.5) ? srcPre : unpremultiply(srcPre);
   vec4 d = unpremultiply(dstPre);
 
   // PSDTool 3-component alpha compositing


### PR DESCRIPTION
## Summary
- Add `srcStraightAlpha` parameter to `PsdCanvasCompositor.composite()`
- Add `uSrcStraightAlpha` uniform to `psd_composite.frag` fragment shader
- When enabled, skips un-premultiply on source texture, matching inox2d's straight-alpha texture pipeline

Part of the fix for dark mesh seam artifacts (utsutsu2d#14).

## Test plan
- [x] Verified with Aka.inx model — dark seams eliminated at mesh boundaries
- [x] PSD compositor correctly handles straight-alpha source textures
- [x] No regression in existing blend mode behavior (backward compatible, default=false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)