### PR TITLE
feat(PsdReader): expose PSD clipping bit as isClipping on PsdLayerNode

### DIFF
--- a/lib/src/psd_layer_node.dart
+++ b/lib/src/psd_layer_node.dart
@@ -21,6 +21,12 @@ class PsdLayerNode {
   /// PSD blend mode string (e.g. 'Normal', 'Multiply', 'Screen').
   final String blendMode;
 
+  /// True when this layer has the PSD clipping bit set (clipping = 1).
+  ///
+  /// A clipping layer is composited only within the opaque pixels of the
+  /// first non-clipping layer below it in the same group ("clip to base").
+  final bool isClipping;
+
   PsdLayerNode({
     required this.name,
     required this.isGroup,
@@ -34,6 +40,7 @@ class PsdLayerNode {
     List<PsdLayerNode>? children,
     this.pngBytes,
     this.blendMode = 'Normal',
+    this.isClipping = false,
   }) : children = children ?? [];
 
   /// The raw name without `!` or `*` prefix.

--- a/lib/src/psd_reader.dart
+++ b/lib/src/psd_reader.dart
@@ -123,6 +123,7 @@ class PsdReader {
           bottom: layer.bottom,
           pngBytes: pngBytes,
           blendMode: _psdBlendModeString(layer.blendMode),
+          isClipping: (layer.clipping ?? 0) == 1,
         );
         stack.last.add(node);
       }


### PR DESCRIPTION
Add `isClipping` bool field to `PsdLayerNode`. When a PSD layer has `layer.clipping == 1` (clip to layer below), the field is set to true.

Previously this information was parsed by the image package but silently discarded, making it impossible for downstream tools (e.g. inp_builder) to detect clipping groups and generate the corresponding `masks` field in INP/INX JSON.